### PR TITLE
Publish API docs to GitHub Pages via amp-catalog

### DIFF
--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,20 @@
+name: Publish API docs
+
+# Publishes this API's Swagger UI to https://hmcts.github.io/<repo>/ on release.
+# All the work lives in the shared catalog workflow; this repo only declares
+# where its OpenAPI spec is. See https://github.com/hmcts/amp-catalog.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: hmcts/amp-catalog/.github/workflows/publish-swagger-ui.yml@v1
+    with:
+      openapi_path: src/main/resources/openapi/cp-caseadmin-dcs-fulfilment.openapi.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# API CP Crime CaseAdmin DCS Fulfilment
+# API CP Crime Case Admin DCS Fulfilment
 
 The Common Platform Case Admin API provides the capability to track the status of case administration requests sent to Digital Case System (DCS).
 


### PR DESCRIPTION
Add the caller workflow and replace the retired SwaggerHub virtserver
URL with the standard server URL pattern.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
